### PR TITLE
feat: enable configurable timeout for connection handlers

### DIFF
--- a/lib/tcp/server/server.ex
+++ b/lib/tcp/server/server.ex
@@ -195,7 +195,8 @@ defmodule Modbux.Tcp.Server do
           Server.Supervisor.start_child(state.sup_pid, Server.Handler, [
             socket,
             state.model_pid,
-            state.parent_pid
+            state.parent_pid,
+            state.timeout
           ])
 
         Logger.debug("(#{__MODULE__}) New Client socket: #{inspect(socket)}, pid: #{inspect(pid)}")

--- a/lib/tcp/server/server_handler.ex
+++ b/lib/tcp/server/server_handler.ex
@@ -10,15 +10,17 @@ defmodule Modbux.Tcp.Server.Handler do
 
   defstruct model_pid: nil,
             parent_pid: nil,
-            socket: nil
+            socket: nil,
+            timeout: nil
 
   @spec start_link([...]) :: :ignore | {:error, any} | {:ok, pid}
-  def start_link([socket, model_pid, parent_pid]) do
-    GenServer.start_link(__MODULE__, [socket, model_pid, parent_pid])
+  def start_link([socket, model_pid, parent_pid, timeout]) do
+    GenServer.start_link(__MODULE__, [socket, model_pid, parent_pid, timeout])
   end
 
-  def init([socket, model_pid, parent_pid]) do
-    {:ok, %Handler{model_pid: model_pid, socket: socket, parent_pid: parent_pid}}
+  def init([socket, model_pid, parent_pid, timeout]) do
+    state = %Handler{model_pid: model_pid, socket: socket, parent_pid: parent_pid, timeout: timeout}
+    {:ok, state, timeout}
   end
 
   def handle_info({:tcp, socket, data}, state) do
@@ -40,7 +42,7 @@ defmodule Modbux.Tcp.Server.Handler do
         Logger.debug("(#{__MODULE__}) Message for another slave")
     end
 
-    {:noreply, state}
+    {:noreply, state, state.timeout}
   end
 
   def handle_info({:tcp_closed, _socket}, state) do


### PR DESCRIPTION

 **Summary:**
Pass server timeout configuration to individual client handlers. Handlers now inherit the server's timeout setting instead of using hardcoded :infinity timeout.

  **Changes:**
  - server.ex: Pass state.timeout to handler when spawning new connections
  - server_handler.ex: Accept timeout parameter and return it from init/1
  - Handlers now properly inherit server timeout setting